### PR TITLE
Fix demo and a bug where space in data-rss URL causes 422 error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
 node_modules
 /dist
+/demo/retainable.css
+/demo/retainable.js
 
 # local env files
 .env.local

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Options are passed in as data attributes on the entry point div
 
     <script src="/retainable.js"></script>
 
-Alternatively there is an example of a widget style script in the demo folder, that injects the CSS & Script tags into the page (you still need to add the entry point div.
+Alternatively there is an example of a widget style script in the demo folder, that injects the CSS & Script tags into the page (you still need to add the entry point div. To run the demo, first build the application with `npm run build`.
+
 ## Views
 The widget has two distinct views
 ### Index view

--- a/demo/one-line-demo.html
+++ b/demo/one-line-demo.html
@@ -17,6 +17,6 @@
          data-buttonclass="btn btn-primary"
          data-offset="-100"></div>
 
-    <script src="https://www.retainable.io/assets/retainable/rss-embed/retainable-rss-embed.js"></script>
+    <script src="retainable-rss-embed.js"></script>
 </body>
 </html>

--- a/demo/retainable-rss-embed.js
+++ b/demo/retainable-rss-embed.js
@@ -1,10 +1,10 @@
 var container = document.getElementById("retainable-rss-embed");
 if (container) {
     var css = document.createElement('link');
-    css.href = "https://www.retainable.io/assets/retainable/rss-embed/retainable.css";
+    css.href = "/retainable.css";
     css.rel = "stylesheet"
     document.getElementsByTagName('head')[0].appendChild(css);
     var script = document.createElement('script');
-    script.src = "https://www.retainable.io/assets/retainable/rss-embed/retainable.js";
+    script.src = "/retainable.js";
     document.getElementsByTagName('body')[0].appendChild(script);
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "build": "vue-cli-service build && cp dist/retainable.js dist/retainable.css demo/",
     "test:unit": "vue-cli-service test:unit",
     "lint": "vue-cli-service lint"
   },

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -17,7 +17,7 @@ export function getPosts({ commit }, rss) {
       rssItemsCount = null;
     }
     return {
-      rssUrl: rssUrlWithOptions[0],
+      rssUrl: rssUrlWithOptions[0] ? rssUrlWithOptions[0].trim() : rssUrlWithOptions[0],
       rssItemsCount: rssItemsCount
     }
   });


### PR DESCRIPTION
Currently the demo is broken since the retainable.io website is not working. I replaced the external CSS/JS references with the built files and tested the demo site with `npx serve .` in the demo folder.

I also fixed a bug where when a `data-rss` URL has a leading space, the RSS API returns a 422 status code by trimming all RSS feed URLs.